### PR TITLE
Define Results API

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -4,37 +4,199 @@ info:
   version: "1.0.0"
   title: "SplathonAPI"
 host: "localhost"
-basePath: "/splathon/v1"
+basePath: "/splathon/"
 schemes:
   - "https"
 tags:
-- name: "sample1"
-  description: "サンプル用のtag"
-- name: "sample2"
-  description: "サンプル用のtag"
+- name: "result"
+  description: "リザルト一覧"
+
 paths:
-  "/user/{id}":
+  "/v{eventId}/results":
     get:
       tags:
-      - "sample1"
-      description: "サンプルコード"
-      operationId: "getUserById"
+      - "result"
+      description: "リザルト一覧を返す。リザルトと言いつつ終了していない未来のマッチも返す。ゲスト・管理アプリ両方から使う。team_idを指定するとそのチームのみの結果が返ってくる。"
+      operationId: "getResult"
       parameters:
-      - name: id
+      - name: eventId
         in: path
-        description: user id
         required: true
+        type: number
+      - name: team_id
+        in: query
+        description: team id
         type: number
       responses:
         200:
           description: Success
           schema:
-            $ref: "#/definitions/SampleObj"
+            $ref: "#/definitions/Results"
+
 definitions:
-  SampleObj:
+  Results:
+    description: "予選/決勝Tのリザルト。予選/決勝Tは同じ構造なのでフラットにできるがクライアントがトーナメント表だせる拡張性持たせるために別フィールドで持つ。"
     type: object
     properties:
-      id:
-        type: integer
-      username:
+      qualifiers:
+        type: array
+        items:
+          $ref: "#/definitions/Round"
+      tournament:
+        type: array
+        items:
+          $ref: "#/definitions/Round"
+
+  Round:
+    description: "予選/決勝Tラウンド両方扱う。"
+    type: object
+    required:
+      - name
+    properties:
+      name:
+        description: "ラウンド名。e.g. 予選第1ラウンド, 決勝T1回戦, 決勝戦"
         type: string
+      round:
+        description: "何ラウンドか。i.e. 予選第Nラウンド, 決勝T N回戦"
+        type: integer
+        format: int32
+      rooms:
+        type: array
+        items:
+          $ref: '#/definitions/Room'
+
+  Room:
+    description: "Roomごとのマッチ"
+    type: object
+    required:
+      - name
+      - matches
+    properties:
+      # Room ID is needless as client-server I/F?
+      id:
+        description: "Room ID."
+        type: integer
+        format: int32
+      name:
+        type: string
+      matches:
+        type: array
+        items:
+          $ref: "#/definitions/Match"
+
+  Match:
+    type: object
+    required:
+      - id
+      - teamAlpha
+      - teamBravo
+    properties:
+      id:
+        description: "Match ID"
+        type: integer
+        format: int32
+      winner:
+        type: string
+        description: "勝者がどちらか。または引き分け。"
+        enum:
+          - "alpha"
+          - "bravo"
+          - "draw"
+      order:
+        description: "Room内でのマッチの順番"
+        type: integer
+        format: int32
+      maxNumOfBattle:
+        description: "このマッチで最大何戦するか。例えば予選は2戦。決勝TはBO3とした場合値は3だけど2戦で勝敗が決まり終了することもある。"
+        type: integer
+        format: int32
+      teamAlpha:
+        $ref: "#/definitions/Team"
+      teamBravo:
+        $ref: "#/definitions/Team"
+      battles:
+        type: array
+        items:
+          $ref: "#/definitions/Battle"
+
+  Team:
+    type: object
+    required:
+      - id
+      - name
+      - companyName
+    properties:
+      id:
+        description: "Team ID"
+        type: integer
+        format: int32
+      name:
+        type: string
+      companyName:
+        type: string
+      members:
+        type: array
+        items:
+          $ref: "#/definitions/Member"
+
+  Member:
+    type: object
+    required:
+      - name
+    properties:
+      id:
+        description: "Member ID (Slack ID かも?)"
+        type: integer
+        format: int32
+      name:
+        type: string
+      icon:
+        description: "Slack icon URL"
+        type: string
+
+  Battle:
+    description: "バトル。勝敗などは決まってない状態のこともある。"
+    type: object
+    required:
+      - id
+      - order
+    properties:
+      id:
+        description: "Battle ID"
+        type: integer
+        format: int32
+      winner:
+        type: string
+        description: "勝者がどちらか。"
+        enum:
+          - "alpha"
+          - "bravo"
+      order:
+        description: "何戦目か"
+        type: integer
+        format: int32
+      rule:
+        type: object
+        properties:
+          key:
+            type: string
+            description: "Rule key. ref: https://splatoon2.ink/data/locale/ja.json"
+            enum:
+              - "turf_war"
+              - "splat_zones"
+              - "tower_control"
+              - "rainmaker"
+              - "clam_blitz"
+          name:
+            description: "Localized rule name."
+            type: string
+      stage:
+        type: object
+        properties:
+          id:
+            description: "Stage ID. ref: https://splatoon2.ink/data/locale/ja.json"
+            type: integer
+            format: int32
+          name:
+            description: "Localized stage name."
+            type: string

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -22,11 +22,13 @@ paths:
       - name: eventId
         in: path
         required: true
-        type: number
+        type: integer
+        format: int64
       - name: team_id
         in: query
         description: team id
-        type: number
+        type: integer
+        format: int64
       responses:
         200:
           description: Success

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -106,10 +106,6 @@ definitions:
         description: "Room内でのマッチの順番"
         type: integer
         format: int32
-      maxNumOfBattle:
-        description: "このマッチで最大何戦するか。例えば予選は2戦。決勝TはBO3とした場合値は3だけど2戦で勝敗が決まり終了することもある。"
-        type: integer
-        format: int32
       teamAlpha:
         $ref: "#/definitions/Team"
       teamBravo:


### PR DESCRIPTION
ref: #3 (#8 とは結構違うので別p-r作りました。)

### ポイント
- 予選と決勝Tの構造を同じ構造で表現するようにした。これで基本的にはゲスト・管理用アプリ両者とも予選・決勝の違いを意識せず透過的に扱えるハズ。
- 決勝Tやマッチ内の各バトルは既存のSplathon railsアプリにはない新しい概念なので特に注意。このAPI定義はあくまで server <=> client のインターフェスではあるけど、 決勝TのマッチはDBレベルでもほぼ予選と同じにしようかと考えてる。