### PR TITLE
Add Update Battle API

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -8,7 +8,7 @@ basePath: "/splathon/"
 schemes:
   - "https"
 consumes:
-  - "application/json; charset=utf-8"
+  - "application/json"
 produces:
   - "application/json; charset=utf-8"
 tags:
@@ -70,6 +70,37 @@ paths:
           description: Success
           schema:
             $ref: "#/definitions/Match"
+        default:
+          description: Generic error
+          schema:
+            $ref: "#/definitions/Error"
+
+    post:
+      tags:
+      - "match"
+      - "admin"
+      description: "Update a battle data in the match."
+      operationId: "updateBattle"
+      parameters:
+      - name: eventId
+        in: path
+        required: true
+        type: integer
+        format: int64
+      - name: matchId
+        in: path
+        required: true
+        description: match id
+        type: integer
+        format: int64
+      - name: battle
+        in: body
+        required: true
+        schema:
+          $ref: "#/definitions/Battle"
+      responses:
+        200:
+          description: Success
         default:
           description: Generic error
           schema:
@@ -246,13 +277,12 @@ definitions:
     description: "バトル。勝敗などは決まってない状態のこともある。"
     type: object
     required:
-      - id
       - order
     properties:
       id:
         description: "Battle ID"
         type: integer
-        format: int32
+        format: int64
       winner:
         type: string
         description: "勝者がどちらか。"
@@ -265,6 +295,8 @@ definitions:
         format: int32
       rule:
         type: object
+        required:
+          - key
         properties:
           key:
             type: string
@@ -280,6 +312,8 @@ definitions:
             type: string
       stage:
         type: object
+        required:
+          - id
         properties:
           id:
             description: "Stage ID. ref: https://splatoon2.ink/data/locale/ja.json"


### PR DESCRIPTION
swagger UI: http://petstore.swagger.io/?url=https://raw.githubusercontent.com/splathon/splathon-api/update-battle/docs/swagger.yaml#/admin/updateBattle

### Example
GET match API (https://splathon-api.appspot.com/splathon/v9/matches/1763) を叩くとすでにあればすでにあるbattleの、なければorderだけ入ったテンプレbattleオブジェクトがかえってくる。

この battle オブジェクトを Update battle API に渡すと更新するか結果を追加する。
リクエストのbattleは order,rule.key,stage.id が required. winner はオプショナル。

```
curl --header "Content-Type: application/json" --request POST -d '{"order": 2, "rule": {"key": "turf_war"}, "stage": {"id": 3}, "winner": "bravo"}' https://splathon-api.appspot.com/splathon/v9/matches/1763
```

UpdateBattleRequest みたいな新オブジェクトを作ったほうがキレイな気はしたけど同じ Battle オブジェクト使いまわしたほうが早いかもと思ったので使いまわした。
けど変えたほうがよかったらいってください。 @koutalou 

API の実装もできてるけどまだログインがないこと、テスト用データベース作ってないという2点から動かないようにしてます。