### PR TITLE
Add Event API which returns general event data

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -20,6 +20,26 @@ tags:
   description: "予選ランキング"
 
 paths:
+  "/v{eventId}/event":
+    get:
+      description: "Return event data"
+      operationId: "getEvent"
+      parameters:
+      - name: eventId
+        in: path
+        required: true
+        type: integer
+        format: int64
+      responses:
+        200:
+          description: Success
+          schema:
+            $ref: "#/definitions/Event"
+        default:
+          description: Generic error
+          schema:
+            $ref: "#/definitions/Error"
+
   "/v{eventId}/results":
     get:
       tags:
@@ -294,34 +314,9 @@ definitions:
         type: integer
         format: int32
       rule:
-        type: object
-        required:
-          - key
-        properties:
-          key:
-            type: string
-            description: "Rule key. ref: https://splatoon2.ink/data/locale/ja.json"
-            enum:
-              - "turf_war"
-              - "splat_zones"
-              - "tower_control"
-              - "rainmaker"
-              - "clam_blitz"
-          name:
-            description: "Localized rule name."
-            type: string
+        $ref: "#/definitions/Rule"
       stage:
-        type: object
-        required:
-          - id
-        properties:
-          id:
-            description: "Stage ID. ref: https://splatoon2.ink/data/locale/ja.json"
-            type: integer
-            format: int32
-          name:
-            description: "Localized stage name."
-            type: string
+        $ref: "#/definitions/Stage"
 
   Ranking:
     description: "予選ランキング"
@@ -365,3 +360,54 @@ definitions:
         type: array
         items:
           $ref: "#/definitions/Team"
+
+  Event:
+    type: object
+    required:
+      - name
+      - numbering
+    properties:
+      name:
+        type: string
+      numbering:
+        type: integer
+        format: int32
+      rules:
+        type: array
+        items:
+          $ref: "#/definitions/Rule"
+      stages:
+        type: array
+        items:
+          $ref: "#/definitions/Stage"
+
+  Rule:
+    type: object
+    required:
+      - key
+    properties:
+      key:
+        type: string
+        description: "Rule key. ref: https://splatoon2.ink/data/locale/ja.json"
+        enum:
+          - "turf_war"
+          - "splat_zones"
+          - "tower_control"
+          - "rainmaker"
+          - "clam_blitz"
+      name:
+        description: "Localized rule name."
+        type: string
+
+  Stage:
+    type: object
+    required:
+      - id
+    properties:
+      id:
+        description: "Stage ID. ref: https://splatoon2.ink/data/locale/ja.json"
+        type: integer
+        format: int32
+      name:
+        description: "Localized stage name."
+        type: string


### PR DESCRIPTION
swagger UI: http://petstore.swagger.io/?url=https://raw.githubusercontent.com/splathon/splathon-api/event-api/docs/swagger.yaml#/default/getEvent

イベント名と共にルルステ返すイベント情報全般API

battle の更新にルルステのデータがいるハズ。ルルステはあとから画像とかも足そうと思えば足せそう

