### PR TITLE
Update host in API definition

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -3,7 +3,7 @@ info:
   description: "Splathonで使うAPI"
   version: "1.0.0"
   title: "SplathonAPI"
-host: "localhost"
+host: "splathon-api-us.appspot.com"
 basePath: "/splathon/"
 schemes:
   - "https"


### PR DESCRIPTION
ちゃんとhostを指定することによってswagger UIからcurlコマンドとか作りやすくなることに気づいた(swaggerヌーブ感)