### PR TITLE
Define Reception related APIs

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -18,6 +18,10 @@ tags:
   description: "マッチ"
 - name: "ranking"
   description: "予選ランキング"
+- name: "admin"
+  description: "管理機能"
+- name: "reception"
+  description: "受付機能"
 
 paths:
   "/v{eventId}/login":
@@ -191,6 +195,90 @@ paths:
           description: Success
           schema:
             $ref: "#/definitions/Teams"
+        default:
+          description: Generic error
+          schema:
+            $ref: "#/definitions/Error"
+
+  "/v{eventId}/reception":
+    get:
+      tags:
+      - "reception"
+      parameters:
+      - name: eventId
+        in: path
+        required: true
+        type: integer
+        format: int64
+      - name: "X-SPLATHON-API-TOKEN"
+        in: header
+        type: string
+        required: true
+      responses:
+        200:
+          description: Success
+          schema:
+            $ref: "#/definitions/ReceptionResponse"
+        default:
+          description: Generic error
+          schema:
+            $ref: "#/definitions/Error"
+
+  "/v{eventId}/reception/{splathonReceptionCode}":
+    get:
+      description: "参加者情報取得API"
+      tags:
+      - "reception"
+      - "admin"
+      parameters:
+      - name: eventId
+        in: path
+        required: true
+        type: integer
+        format: int64
+      - name: splathonReceptionCode
+        description: "ReceptionResponse.splathon.code と同じもの(たぶん内部SlackID)."
+        in: path
+        required: true
+        type: string
+      - name: "X-SPLATHON-API-TOKEN"
+        in: header
+        type: string
+        required: true
+      responses:
+        200:
+          description: Success
+          schema:
+            $ref: "#/definitions/ReceptionPartcipantsDataResponse"
+        default:
+          description: Generic error
+          schema:
+            $ref: "#/definitions/Error"
+
+  "/v{eventId}/reception/{splathonReceptionCode}/register":
+    post:
+      description: "参加登録API"
+      tags:
+      - "reception"
+      - "admin"
+      parameters:
+      - name: eventId
+        in: path
+        required: true
+        type: integer
+        format: int64
+      - name: splathonReceptionCode
+        description: "ReceptionResponse.splathon.code と同じもの(たぶん内部SlackID)."
+        in: path
+        required: true
+        type: string
+      - name: "X-SPLATHON-API-TOKEN"
+        in: header
+        type: string
+        required: true
+      responses:
+        200:
+          description: Success
         default:
           description: Generic error
           schema:
@@ -468,3 +556,93 @@ definitions:
       name:
         description: "Localized stage name."
         type: string
+
+  ReceptionResponse:
+    type: object
+    properties:
+      building:
+        description: "ビル入館情報"
+        $ref: "#/definitions/ReceptionCode"
+      splathon:
+        description: "Splathon会場受付情報"
+        $ref: "#/definitions/ReceptionCode"
+
+  ReceptionCode:
+    type: object
+    description: "ビル入館情報/Splathon会場受付情報"
+    properties:
+      name:
+        description: "Splathon会場入場コード/XXXビル入館コード"
+        type: string
+      description:
+        description: "入場の説明"
+        type: string
+      short_text:
+        description: "コードの説明"
+        type: string
+      qrcode_img:
+        description: "Image URL of QR code"
+        type: string
+      code:
+        type: string
+      code_type:
+        type: string
+        enum:
+          - "qrcode"
+          - "barcode"
+
+  ReceptionPartcipantsDataResponse:
+    type: object
+    properties:
+      description:
+        description: "受付の仕方の説明や注意点などのフリーテキスト。"
+        type: string
+      slack_internal_id:
+        description: "参加者の Slack Internal ID"
+        type: string
+      participants:
+        description: "1つのSlackIDで複数の参加者をカバーしている。また
+        participants とは別に参加者情報のない同伴者が存在する可能性があり、
+        もしいる場合は has_companion flag が true となる"
+        type: array
+        items:
+          $ref: "#/definitions/ParticipantReception"
+
+  ParticipantReception:
+    type: object
+    properties:
+      nickname:
+        type: string
+        description: "ハンドルネーム。 e.g. みーくん"
+      fullname_kana:
+        type: string
+        description: "カタカナのフルネーム。 e.g. ヤマダタロウ"
+      company_name:
+        type: string
+        description: "所属企業名"
+      team_name:
+        description: "チーム名"
+        type: string
+      team_id:
+        description: "チームID(一応)"
+        type: integer
+        format: int64
+      participant_fee:
+        type: integer
+        format: int32
+        description: "合計参加費(円)"
+      join_party:
+        type: boolean
+        description: "懇親会に参加するか否か"
+      is_staff:
+        type: boolean
+        description: "スタッフかどうか"
+      is_player:
+        type: boolean
+        description: "playerとして参加するかどうか。falseならスタッフか観戦"
+      has_switch_dock:
+        type: boolean
+        description: "Nintendo Switch doc を持ってきたか"
+      has_companion:
+        type: boolean
+        description: "同伴者がいるかどうか。いる場合は用スプレッドシート確認。"


### PR DESCRIPTION
Fix #6

Swagger UI: http://petstore.swagger.io/?url=https://raw.githubusercontent.com/splathon/splathon-api/reception/docs/swagger.yaml#/