### PR TITLE
Define Team Detail API

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -200,6 +200,32 @@ paths:
           schema:
             $ref: "#/definitions/Error"
 
+  "/v{eventId}/teams/{team_id}":
+    get:
+      description: "Return detail team data"
+      operationId: "getTeamDetail"
+      parameters:
+      - name: eventId
+        in: path
+        required: true
+        type: integer
+        format: int64
+      - name: team_id
+        in: path
+        required: true
+        description: team id
+        type: integer
+        format: int64
+      responses:
+        200:
+          description: Success
+          schema:
+            $ref: "#/definitions/Team"
+        default:
+          description: Generic error
+          schema:
+            $ref: "#/definitions/Error"
+
   "/v{eventId}/reception":
     get:
       tags:


### PR DESCRIPTION
UI: http://petstore.swagger.io/?url=https://raw.githubusercontent.com/splathon/splathon-api/team-detail/docs/swagger.yaml#/default/getTeamDetail

スコアボードのチーム詳細ページでつかう