### PR TITLE
🚨 Update API token to required for Get Result API

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -201,6 +201,7 @@ paths:
         format: int64
       - name: "X-SPLATHON-API-TOKEN"
         in: header
+        required: true
         type: string
       responses:
         200:


### PR DESCRIPTION
## Why

* API Tokenが Optionalだが、基本Requiredだと思う
* Generaterの制限でもあるが、DartのOptional引数はLabelが必要でこのままだと `X_SPLATHON_API_TOKEN: token` みたいなコードを書かないといけなくてプチ辛み
* たぶんServerの実装には影響ない（必ず付くだけなので）のでRequiredにしたい

## What

* ResultApi の `X_SPLATHON_API_TOKEN` をRequired に変更した